### PR TITLE
Fixed AZDO_WORK set to empty string

### DIFF
--- a/linux/ubuntu/versioned/dockerfile.template
+++ b/linux/ubuntu/versioned/dockerfile.template
@@ -9,7 +9,7 @@ COPY ./runAgent.sh /azdo/
 RUN chmod +x /azdo/runAgent.sh \
  && set -x \
  && cd /azdo \
- && curl -s -fSL https://vstsagentpackage.azureedge.net/agent/$[AZDO_AGENT_VERSION]/vsts-agent-linux-x64-$[AZDO_AGENT_VERSION].tar.gz -o agent.tgz \
+ && curl -s -fSL https://download.agent.dev.azure.com/agent/$[AZDO_AGENT_VERSION]/vsts-agent-linux-x64-$[AZDO_AGENT_VERSION].tar.gz -o agent.tgz \
  && mkdir agent \
  && cd agent \
  && tar -xzf ../agent.tgz \

--- a/linux/ubuntu/versioned/runAgent.sh
+++ b/linux/ubuntu/versioned/runAgent.sh
@@ -52,7 +52,7 @@ fi
 
 if [ -n "$AZDO_WORK" ]; then
   AZDO_WORK="$(eval echo "$AZDO_WORK")"
-  export AZDO_WORK=
+  export AZDO_WORK
   mkdir -p "$AZDO_WORK"
 fi
 


### PR DESCRIPTION
Hello,

Fixed a bug `runAgent.sh` setting the `AZDO_WORK` var to empty string. Currently, any attempt to run the container will fail with this message.

```
mkdir: cannot create directory '': No such file or directory
```

Thank you.